### PR TITLE
Harden release workflow: packages:write, fetch-depth:0, ghcr.io login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     permissions:
+      packages: write
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Print version info
         id: semver
@@ -33,11 +36,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - name: Login to DockerHub
+      - name: Log in to the GitHub Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: 1gtm
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run checks
         run: |


### PR DESCRIPTION
## Summary
- Add `permissions: packages: write` on the build job so the workflow's `GITHUB_TOKEN` can push images to the org's ghcr.io packages.
- Add `with: fetch-depth: 0` to the `actions/checkout` step so the full git history is available (e.g. for `git describe` in `make version`).
- Switch container-registry login to **ghcr.io** with `${{ github.actor }}` / `${{ secrets.GITHUB_TOKEN }}` via `docker/login-action` (replacing `1gtm` / `DOCKERHUB_TOKEN`, and any inline `docker login` shell command).

## Required follow-up before next release
On the ghcr.io package settings page (Org → Packages → `<this image>` → Package settings → Manage Actions access), add this repo with role **Write** (or **Admin**). Without that, `GITHUB_TOKEN` will hit `permission_denied: write_package` on push.

## Test plan
- [ ] CI passes on this PR.
- [ ] Next tag-triggered release publishes successfully to `ghcr.io/kubedb/<image>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)